### PR TITLE
MOE Sync 2020-08-19

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "google_bazel_common",
-    sha256 = "48a209fed9575c9d108eaf11fb77f7fe6178a90135e4d60cac6f70c2603aa53a",
-    strip_prefix = "bazel-common-9e3880428c1837db9fb13335ed390b7e33e346a7",
-    urls = ["https://github.com/google/bazel-common/archive/9e3880428c1837db9fb13335ed390b7e33e346a7.zip"],
+    sha256 = "7e5584a1527390d55c972c246471cffd4c68b4c234d288f6afb52af8619c4560",
+    strip_prefix = "bazel-common-d58641d120c2ad3d0afd77b57fbaa78f3a97d914",
+    urls = ["https://github.com/google/bazel-common/archive/d58641d120c2ad3d0afd77b57fbaa78f3a97d914.zip"],
 )
 
 load("@google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,8 +1,17 @@
 # Description:
 #   Tools for Inject Common
 
+load("//tools/build_defs/testing:bzl_library.bzl", "bzl_library")
+
 package(default_visibility = ["//:src"])
 
 exports_files([
     "pom-template.xml",
 ])
+
+bzl_library(
+    name = "maven_bzl",
+    srcs = ["maven.bzl"],
+    parse_tests = False,
+    visibility = ["//visibility:private"],
+)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,7 +1,7 @@
 # Description:
 #   Tools for Inject Common
 
-load("//tools/build_defs/testing:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//:src"])
 
@@ -12,6 +12,5 @@ exports_files([
 bzl_library(
     name = "maven_bzl",
     srcs = ["maven.bzl"],
-    parse_tests = False,
     visibility = ["//visibility:private"],
 )


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add bzl_library rules for .bzl files without one.

a52e53a4e0da62e4f2880dc74dd92335d07e493d

-------

<p> Switch to correct bzl_library for open source.

50cb2239ee5613ca878291207b7cccd6039c0111

-------

<p> Update bazel_common version for inject_common.

Similar to https://github.com/google/flogger/issues/127, inject-common Travis builds are erroring with "Unknown host: maven.ibiblio.org", so hopefully this will fix it. This has probably been true at head for months at minimum, AFAICT.

ed9cc9c1d94d838ac17c02169d2f5d9bf199964c